### PR TITLE
[vcpkg] Update CMake to 3.25.1

### DIFF
--- a/scripts/vcpkgTools.xml
+++ b/scripts/vcpkgTools.xml
@@ -15,25 +15,25 @@
         <archiveName>python-3.10.7.nupkg.zip</archiveName>
     </tool>
     <tool name="cmake" os="windows">
-        <version>3.25.0</version>
-        <exeRelativePath>cmake-3.25.0-windows-i386\bin\cmake.exe</exeRelativePath>
-        <url>https://github.com/Kitware/CMake/releases/download/v3.25.0/cmake-3.25.0-windows-i386.zip</url>
-        <sha512>6ef267b117af3369a72186f1c892e8f112b8013899f4b7a6573ea0d678b2ac41e84adb760ca793ebafa37852dfb9e7e1bc40d14f73ebb4cfedae9ab2f504b417</sha512>
-        <archiveName>cmake-3.25.0-windows-i386.zip</archiveName>
+        <version>3.25.1</version>
+        <exeRelativePath>cmake-3.25.1-windows-i386\bin\cmake.exe</exeRelativePath>
+        <url>https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-windows-i386.zip</url>
+        <sha512>4a84abdb53781178a99046aa09cf6a6b2bfe159d6b6bbdd2449839d2f50b872b4cc783c44774343b6122ec9400bcfdec65fffd4a246575ba55d178bc180f6adc</sha512>
+        <archiveName>cmake-3.25.1-windows-i386.zip</archiveName>
     </tool>
     <tool name="cmake" os="osx">
-        <version>3.25.0</version>
-        <exeRelativePath>cmake-3.25.0-macos-universal/CMake.app/Contents/bin/cmake</exeRelativePath>
-        <url>https://github.com/Kitware/CMake/releases/download/v3.25.0/cmake-3.25.0-macos-universal.tar.gz</url>
-        <sha512>d37017c8917e284d1102e42dc3dcd5f0c956f70720b357a530766980f7b2c595c02d273dfb7d5a01bc6f7680bff6742354f528a49033f43b9b1ee7d8ad863f0f</sha512>
-        <archiveName>cmake-3.25.0-macos-universal.tar.gz</archiveName>
+        <version>3.25.1</version>
+        <exeRelativePath>cmake-3.25.1-macos-universal/CMake.app/Contents/bin/cmake</exeRelativePath>
+        <url>https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-macos-universal.tar.gz</url>
+        <sha512>6009ff799ee516c1ca3bf3a31bacdd59fc48f772a03c822f49e1e9b6a6582e64d75c6005a90574539d61b7094dfe36bfe4b4c1560a4fb7d1287be472c0fd146a</sha512>
+        <archiveName>cmake-3.25.1-macos-universal.tar.gz</archiveName>
     </tool>
     <tool name="cmake" os="linux">
-        <version>3.25.0</version>
-        <exeRelativePath>cmake-3.25.0-linux-x86_64/bin/cmake</exeRelativePath>
-        <url>https://github.com/Kitware/CMake/releases/download/v3.25.0/cmake-3.25.0-linux-x86_64.tar.gz</url>
-        <sha512>fe59f499a6ca2c651457868ecd9c3541a3c9bcdfaef0e5b4ca18a9fb3eb12c097a19564333342f853b2b7ddef173128090baa4774c46cb8ee639b4fe7cc3add3</sha512>
-        <archiveName>cmake-3.25.0-linux-x86_64.tar.gz</archiveName>
+        <version>3.25.1</version>
+        <exeRelativePath>cmake-3.25.1-linux-x86_64/bin/cmake</exeRelativePath>
+        <url>https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz</url>
+        <sha512>df456fafa9e63ab0105a6355cc3f66d0567c43172fb424ba75b364f65c6da100dbb303ddd11abd68b42b3b52a90805dfda36aae2468c64c204446f4befda0c78</sha512>
+        <archiveName>cmake-3.25.1-linux-x86_64.tar.gz</archiveName>
     </tool>
     <tool name="cmake" os="freebsd">
         <version>3.20.4</version>


### PR DESCRIPTION
The recent PR #28012 broke my application builds due to https://gitlab.kitware.com/cmake/cmake/-/issues/24209

> https://gitlab.kitware.com/cmake/cmake/-/issues/24209  
> PCH compilations fails on VC++/Ninja if CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP=1

^ The issue shows how easy it is to reproduce this issue on CMake 3.25.0 using `target_precompile_headers`

---

> _Uncertain of the process for bumping CMake, simply based this PR on #28012 from a few days ago._
>
> _Feel free to close if there's an internal process for doing this and y'all will do it. But please get to 3.25.1 soon!_